### PR TITLE
relax ember dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "version": "0.0.13",
   "main": "ember-data.js",
   "dependencies": {
-    "ember": "1.0.0-rc.4"
+    "ember": "~1.0.0-rc.4"
   }
 }


### PR DESCRIPTION
@RobLoach Bower is separately downloading ember `1.0.0-rc.4` since ember-data-shim lists this as a dependency. It ought to accept higher version also, right?
