### PR TITLE
Relax Ember.js dependency for all version 1 releases

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "version": "1.0.0-beta.3",
   "main": "ember-data.js",
   "dependencies": {
-    "ember": "~1.0.0"
+    "ember": "~1"
   }
 }


### PR DESCRIPTION
Hey - not sure if I'm out of line with this, but with Ember's rapid release cycle, we're at version 1.1.2 right now and will soon be at 1.2.0.

I've just changed this to allow all 1.x.x releases. Let me know what you think.

Thanks!
