### PR TITLE
Updated bower, component and package json to beta.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "main": "ember-data.js",
   "dependencies": {
     "ember": "~1.0"

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "ember-data",
   "repo": "components/ember-data",
   "description": "A data persistence library for Ember.js.",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "main": "ember-data.js",
   "scripts": [
     "ember-data.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-ember-data",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "A data persistence library for Ember.js.",
   "keywords": ["ember"],
   "main": "./ember-data.js",


### PR DESCRIPTION
This PR fixes also the warning when trying to install beta.4 using bower.

`mismatch Version declared in the json (1.0.0-beta.3) is different than the resolved one (1.0.0-beta.4)`

@rjackson probably beta.4 could be retagged?
