### PR TITLE
Changed ember version requirements in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "version": "1.0.0-beta.4",
   "main": "ember-data.js",
   "dependencies": {
-    "ember": "1.x"
+    "ember": ">= 1.0.0"
   }
 }


### PR DESCRIPTION
This change will allow for the installation of any version of ember within the v1 range. Where `bower install ember ember-data` previously required you to add a resolution to the bower config.
