### PR TITLE
Tell make to also grab beta.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v1.0.0-beta.6
+VERSION=v1.0.0-beta.7
 
 default:
 	@curl -O http://builds.emberjs.com/tags/$(VERSION)/ember-data.js


### PR DESCRIPTION
Current package is on v1.0.0-beta.7 canary b45e23ba.

This build breaks my app, while new ones do not. Updating
the makefile so I can grab the latest beta from my app while
I wait for newer version to be published to bower via shim
