### PR TITLE
Add license field to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "ember-data",
+  "license": "MIT",
   "version": "v2.3.0-beta.1",
   "main": "ember-data.js",
   "dependencies": {


### PR DESCRIPTION
bower.json is missing the license field. If I'm not mistaken, Ember Data uses the same license as Ember (MIT). https://github.com/components/ember/blob/master/bower.json#L3

Our automated external library requests service is blocking the import of Ember Data canary for this reason.