### PR TITLE
Rename package to ember-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "components-ember-data",
+  "name": "ember-data",
   "version": "2.11.0-beta.1",
   "description": "A data persistence library for Ember.js.",
   "keywords": [
@@ -15,5 +15,6 @@
       "ember-data": { "deps": ["ember"], "exports": "DS" },
       "ember-data.prod": { "deps": ["ember"], "exports": "DS" }
     }
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
refs #37 
Declares the package private so it can not be published to npm (it is already not published).

This allows to use various versions of ember-data easier, most notably with ember-try configs.